### PR TITLE
Add typescript type declaration file.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+export interface Block {
+  scope: string,
+  children: Block[],
+}
+
+/** Parse blocks of text based on indentation. */
+export function parse(text: string): Block[]


### PR DESCRIPTION
This PR will resolve type definitions for `jex-block-parser` in projects that use typescript. No additional configuration needed.