### PR TITLE
Document maxNodes and allow default 100 to be overwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ parse(input)
   { scope: 'world', children: [] } ]
 ```
 
+The maximum number of children is 100 by default. Additional children will be dropped. To allow more children, you can specify `maxNodes` in the second arguments:
+
+```
+parse(input, Infinity)
+```
+
 ### Deep
 
 We don't care about blank lines or the [type of

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ export const collapse = (list, maxNodes = 100) => {
     tail = list.slice(i + 1)
     const nextScopeIndex = findNextEquivalentScope(scope, tail)
     const children = findLinesWithinScope(scope, tail)
-    const collapsedChildren = collapse(children)
+    const collapsedChildren = collapse(children, maxNodes)
     result.push({
       scope,
       children: collapsedChildren,
@@ -55,11 +55,11 @@ export const collapse = (list, maxNodes = 100) => {
     } else {
       break
     }
-  } while (1 && count++ < maxNodes)
+  } while (++count < maxNodes)
 
   return result
 }
 
-export const parse = (text) => {
-  return collapse(text.split('\n').filter(x => x))
+export const parse = (text, maxNodes) => {
+  return collapse(text.split('\n').filter(x => x), maxNodes)
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,7 @@
 import * as mod from '.'
 
-const log = (x) =>
-  console.log(JSON.stringify(x, null, '  '))
+// const log = (x) =>
+//   console.log(JSON.stringify(x, null, '  '))
 
 describe('isWithinScope', () => {
   it('should is', () => {
@@ -161,6 +161,62 @@ describe('collapse', () => {
       },
     ])
   })
+})
+
+describe('maxNodes', () => {
+  const input = `
+- a
+  - b
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+- c
+  - d
+    - e`
+
+  const result = mod.parse(input, 3)
+  expect(result).toEqual(
+    [
+      {
+        'scope': '- a',
+        'children': [
+          {
+            'scope': '  - b',
+            'children': [
+              {
+                'scope': '    - 1',
+                'children': []
+              },
+              {
+                'scope': '    - 2',
+                'children': []
+              },
+              {
+                'scope': '    - 3',
+                'children': []
+              },
+            ]
+          }
+        ]
+      },
+      {
+        'scope': '- c',
+        'children': [
+          {
+            'scope': '  - d',
+            'children': [
+              {
+                'scope': '    - e',
+                'children': []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  )
 })
 
 describe('mac daddy', () => {


### PR DESCRIPTION
Nodes are limited to 100 children by default. This PR adds documentation to the README to make this clear, and provides the ability to override the default.

I can also change the default to unlimited if you prefer. That might be more intuitive.